### PR TITLE
Added delete option to file upload 

### DIFF
--- a/components/puck-fields/upload-file.tsx
+++ b/components/puck-fields/upload-file.tsx
@@ -1,5 +1,5 @@
 import { CustomFieldRenderProps } from "@lib/custom-field-types";
-import { Upload } from "lucide-react";
+import { Upload, X } from "lucide-react";
 import { CustomField } from "@puckeditor/core";
 
 type UploadFileProps = string | undefined;
@@ -37,12 +37,33 @@ function UploadFile({
         </span>
       </label>
       {value && (
-        <div className="mt-4">
+        <div style={{ marginTop: "16px", position: "relative" }}>
           <img
             src={value}
             alt="Uploaded file"
             className="max-w-full h-auto rounded-lg"
           />
+          <button
+            type="button"
+            onClick={() => onChange(undefined)}
+            style={{
+              position: "absolute",
+              top: "4px",
+              right: "4px",
+              backgroundColor: "#6b7280",
+              color: "white",
+              borderRadius: "50%",
+              padding: "4px",
+              border: "none",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            aria-label="Remove image"
+          >
+            <X style={{ width: "16px", height: "16px" }} />
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
* File upload (drag and drop): added delete option -> so images can be changed(deleted) and tests work more smoothly


Closes https://github.com/PfadiMH/puck/issues/99

## Preview

<img width="331" height="451" alt="Bildschirmfoto 2026-02-18 um 07 51 30" src="https://github.com/user-attachments/assets/f91a9152-0c6d-44c8-ba5e-95b53fa638bc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Remove button to clear uploaded images. Users can now easily delete previously uploaded files with a single click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->