### PR TITLE
Add Organigramm component with Hitobito integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ S3_ENDPOINT=http://localhost:9000
 S3_PUBLIC_URL=http://localhost:9000/puck-files
 S3_REGION=us-east-1
 S3_SECRET_ACCESS_KEY=minioadmin
+
+# Hitobito (MiData) API — for Organigramm component
+# HITOBITO_BASE_URL=https://db.scout.ch
+# HITOBITO_API_TOKEN=your-api-token

--- a/app/api/organigramm/route.ts
+++ b/app/api/organigramm/route.ts
@@ -1,0 +1,101 @@
+import { dbService } from "@lib/db/db";
+import { hitobitoClient } from "@lib/hitobito/client";
+import { fetchOrganigramm } from "@lib/hitobito/fetch-organigramm";
+import type { OrganigrammResponse } from "@lib/hitobito/types";
+import { NextRequest, NextResponse } from "next/server";
+
+/** Cache TTL: 1 week in milliseconds */
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const groupIdParam = searchParams.get("groupId");
+
+  if (!groupIdParam) {
+    return NextResponse.json(
+      { error: "Missing required query parameter: groupId" },
+      { status: 400 }
+    );
+  }
+
+  const groupId = Number(groupIdParam);
+  if (Number.isNaN(groupId) || groupId <= 0) {
+    return NextResponse.json(
+      { error: "groupId must be a positive integer" },
+      { status: 400 }
+    );
+  }
+
+  // Check cache first
+  const cached = await dbService.getOrganigrammCache(groupId);
+  const now = Date.now();
+  const isFresh =
+    cached && now - new Date(cached.fetchedAt).getTime() < CACHE_TTL_MS;
+
+  if (isFresh && cached) {
+    const response: OrganigrammResponse = {
+      data: cached.data,
+      stale: false,
+      fetchedAt: cached.fetchedAt.toISOString(),
+    };
+    return NextResponse.json(response, {
+      headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
+    });
+  }
+
+  // Need fresh data — check if Hitobito is configured
+  if (!hitobitoClient) {
+    // No Hitobito configured — serve stale cache if available
+    if (cached) {
+      const response: OrganigrammResponse = {
+        data: cached.data,
+        stale: true,
+        fetchedAt: cached.fetchedAt.toISOString(),
+      };
+      return NextResponse.json(response);
+    }
+    return NextResponse.json(
+      { error: "Hitobito API is not configured (HITOBITO_BASE_URL / HITOBITO_API_TOKEN missing)" },
+      { status: 503 }
+    );
+  }
+
+  // Fetch fresh data from Hitobito
+  try {
+    const data = await fetchOrganigramm(hitobitoClient, groupId);
+    const fetchedAt = new Date();
+
+    // Save to cache
+    await dbService.saveOrganigrammCache({
+      rootGroupId: groupId,
+      fetchedAt,
+      data,
+    });
+
+    const response: OrganigrammResponse = {
+      data,
+      stale: false,
+      fetchedAt: fetchedAt.toISOString(),
+    };
+    return NextResponse.json(response, {
+      headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
+    });
+  } catch (error) {
+    console.error("Failed to fetch Organigramm from Hitobito:", error);
+
+    // If we have stale cache, serve it rather than failing
+    if (cached) {
+      const response: OrganigrammResponse = {
+        data: cached.data,
+        stale: true,
+        fetchedAt: cached.fetchedAt.toISOString(),
+      };
+      return NextResponse.json(response);
+    }
+
+    return NextResponse.json(
+      { error: "Failed to fetch data from Hitobito and no cached data available" },
+      { status: 502 }
+    );
+  }
+}

--- a/components/puck/Organigramm.stories.tsx
+++ b/components/puck/Organigramm.stories.tsx
@@ -1,0 +1,287 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { OrganigrammClient } from "./OrganigrammClient";
+
+const pic = (seed: string) =>
+  `https://api.dicebear.com/9.x/avataaars/svg?seed=${encodeURIComponent(seed)}`;
+
+function mb(
+  id: number,
+  firstName: string,
+  lastName: string,
+  nickname: string | null,
+  role: string,
+  roleName: string,
+  hasPic: boolean
+) {
+  return {
+    id,
+    firstName,
+    lastName,
+    nickname,
+    role,
+    roleName,
+    picture: hasPic ? pic(`${firstName.toLowerCase()}-${id}`) : null,
+  };
+}
+
+/**
+ * Realistic mock data matching the Pfadi Meilen Herrliberg org chart:
+ *   L1: Abteilungsleitung (Arwen, Canyella, Maui)
+ *   L2: Wolfsstufe, Pfadistufe, Piostufe
+ *   L3: Meuten / Trupps with Stufenleitung
+ *   L4: Gruppenleitung
+ */
+const mockOrganigrammData = {
+  data: {
+    group: {
+      id: 1234,
+      name: "Pfadi Meilen Herrliberg",
+      shortName: "Pfadi MH",
+      type: "Group::Abteilung",
+    },
+    members: [
+      mb(1, "Lena", "Baumann", "Arwen", "Group::Abteilung::Abteilungsleitung", "Abteilungsleitung", true),
+      mb(2, "Silvio", "Meier", "Canyella", "Group::Abteilung::Abteilungsleitung", "Abteilungsleitung", true),
+      mb(3, "Florian", "Loew", "Maui", "Group::Abteilung::Abteilungsleitung", "Abteilungsleitung", true),
+      mb(99, "System", "Admin", null, "Group::Abteilung::PowerUser", "PowerUser", false),
+    ],
+    children: [
+      // Wolfsstufe (Rikki-Tikki-Tavi)
+      {
+        group: { id: 2001, name: "Wolfsstufe", shortName: "Rikki-Tikki-Tavi", type: "Group::Woelfe" },
+        members: [
+          mb(10, "Nina", "Roth", "Achaya", "Group::Woelfe::Stufenleitung", "Stufenleitung", true),
+          mb(11, "Sophie", "Mueller", "Peppina", "Group::Woelfe::Stufenleitung", "Stufenleitung", true),
+          mb(20, "Elena", "Gerber", "Zafia", "Group::Woelfe::Stufenleitung", "Stufenleitung", true),
+          mb(21, "Laura", "Brunner", "Zelia", "Group::Woelfe::Stufenleitung", "Stufenleitung", false),
+        ],
+        children: [
+          {
+            group: { id: 3001, name: "Bienli", shortName: "Meute Raschka", type: "Group::Woelfe::Meute" },
+            members: [
+              mb(10, "Nina", "Roth", "Achaya", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", true),
+              mb(11, "Sophie", "Mueller", "Peppina", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", true),
+            ],
+            children: [
+              {
+                group: { id: 4001, name: "Fähnli Raschka", shortName: null, type: "Group::Woelfe::Fahnli" },
+                members: [
+                  mb(12, "Anna", "Keller", "Moana", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                  mb(13, "Lara", "Fischer", "Ayeli", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", false),
+                  mb(14, "Marco", "Huber", "Elua", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                ],
+                children: [],
+              },
+            ],
+          },
+          {
+            group: { id: 3002, name: "Wölfli", shortName: "Meute Akela", type: "Group::Woelfe::Meute" },
+            members: [
+              mb(20, "Elena", "Gerber", "Zafia", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", true),
+              mb(21, "Laura", "Brunner", "Zelia", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", false),
+            ],
+            children: [
+              {
+                group: { id: 4002, name: "Fähnli Akela", shortName: null, type: "Group::Woelfe::Fahnli" },
+                members: [
+                  mb(22, "Tim", "Schmid", "Artus", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", false),
+                  mb(23, "Jonas", "Steiner", "Salero", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                  mb(24, "Lena", "Widmer", "Pachica", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                  mb(25, "Nora", "Frei", "Malea", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", false),
+                ],
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+      // Pfadistufe
+      {
+        group: { id: 2002, name: "Pfadistufe", shortName: "Pfadi", type: "Group::Pfadi" },
+        members: [
+          mb(30, "David", "Graf", "Baski", "Group::Pfadi::Stufenleitung", "Stufenleitung", true),
+          mb(31, "Sarah", "Bieri", "Salita", "Group::Pfadi::Stufenleitung", "Stufenleitung", true),
+          mb(40, "Robin", "Hartmann", "Maeva", "Group::Pfadi::Stufenleitung", "Stufenleitung", true),
+          mb(41, "Julia", "Lang", "Nepomuk", "Group::Pfadi::Stufenleitung", "Stufenleitung", false),
+        ],
+        children: [
+          {
+            group: { id: 3003, name: "Atlantik-Karibik", shortName: null, type: "Group::Pfadi::Trupp" },
+            members: [
+              mb(30, "David", "Graf", "Baski", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", true),
+              mb(31, "Sarah", "Bieri", "Salita", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", true),
+            ],
+            children: [
+              {
+                group: { id: 4003, name: "Ashera", shortName: null, type: "Group::Pfadi::Patrouille" },
+                members: [
+                  mb(32, "Fabian", "Kunz", "Chippa", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  mb(33, "Mia", "Gerber", "Maymana", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  mb(34, "Noah", "Ammann", "Arisca", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  mb(35, "Lea", "Moser", "Calima", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  mb(36, "Jan", "Ritter", "Malinka", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                ],
+                children: [],
+              },
+            ],
+          },
+          {
+            group: { id: 3004, name: "OFI", shortName: null, type: "Group::Pfadi::Trupp" },
+            members: [
+              mb(40, "Robin", "Hartmann", "Maeva", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", true),
+              mb(41, "Julia", "Lang", "Nepomuk", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", false),
+            ],
+            children: [
+              {
+                group: { id: 4004, name: "Patrouille OFI", shortName: null, type: "Group::Pfadi::Patrouille" },
+                members: [
+                  mb(42, "Nico", "Pfister", "Rajah", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  mb(43, "Amelie", "Berger", "Bachuja", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  mb(44, "Andrin", "Bucher", "Leonidas", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  mb(45, "Clara", "Suter", "Thor", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  mb(46, "Dario", "Meier", "Pyro", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  mb(47, "Eva", "Schmid", "Battino", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                ],
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+      // Piostufe
+      {
+        group: { id: 2003, name: "Piostufe", shortName: "Pio", type: "Group::Pio" },
+        members: [
+          mb(50, "Patrick", "Wyss", "Maui", "Group::Pio::Stufenleitung", "Stufenleitung", true),
+        ],
+        children: [
+          {
+            group: { id: 3005, name: "Makena", shortName: null, type: "Group::Pio::Equipe" },
+            members: [
+              mb(50, "Patrick", "Wyss", "Maui", "Group::Pio::Equipe::Stufenleitung", "Stufenleitung", true),
+            ],
+            children: [
+              {
+                group: { id: 4005, name: "Equipe Makena", shortName: null, type: "Group::Pio::Equipe::Gruppe" },
+                members: [
+                  mb(51, "Carla", "Stocker", "Salita", "Group::Pio::Equipe::Leitung", "Gruppenleitung", true),
+                  mb(52, "Lars", "Engel", "Twist", "Group::Pio::Equipe::Leitung", "Gruppenleitung", false),
+                ],
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  stale: false,
+  fetchedAt: new Date().toISOString(),
+};
+
+// Mock fetch so useQuery resolves with mock data
+const createMockFetchDecorator = () => {
+  const originalFetch = globalThis.fetch;
+
+  return (Story: React.ComponentType) => {
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/organigramm")) {
+        return new Response(JSON.stringify(mockOrganigrammData), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return originalFetch(input, init);
+    };
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity },
+      },
+    });
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };
+};
+
+const meta: Meta<typeof OrganigrammClient> = {
+  component: OrganigrammClient,
+  title: "Puck/Organigramm",
+  decorators: [createMockFetchDecorator()],
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OrganigrammClient>;
+
+export const Default: Story = {
+  args: {
+    rootGroupId: 1234,
+    excludedRoles: "",
+    maxDepth: 3,
+    maxVisibleMembers: 4,
+    showPictures: true,
+  },
+};
+
+export const WithExcludedRoles: Story = {
+  args: {
+    rootGroupId: 1234,
+    excludedRoles: "PowerUser",
+    maxDepth: 3,
+    maxVisibleMembers: 4,
+    showPictures: true,
+  },
+};
+
+export const NoPictures: Story = {
+  args: {
+    rootGroupId: 1234,
+    excludedRoles: "",
+    maxDepth: 3,
+    maxVisibleMembers: 4,
+    showPictures: false,
+  },
+};
+
+export const SmallOverflow: Story = {
+  name: "Max 3 Visible (more overflow)",
+  args: {
+    rootGroupId: 1234,
+    excludedRoles: "",
+    maxDepth: 3,
+    maxVisibleMembers: 3,
+    showPictures: true,
+  },
+};
+
+export const ShowAll: Story = {
+  name: "Show All Members",
+  args: {
+    rootGroupId: 1234,
+    excludedRoles: "",
+    maxDepth: 3,
+    maxVisibleMembers: 99,
+    showPictures: true,
+  },
+};
+
+export const NotConfigured: Story = {
+  name: "Not Configured (groupId = 0)",
+  args: {
+    rootGroupId: 0,
+    excludedRoles: "",
+    maxDepth: 3,
+    maxVisibleMembers: 4,
+    showPictures: true,
+  },
+};

--- a/components/puck/Organigramm.tsx
+++ b/components/puck/Organigramm.tsx
@@ -1,0 +1,82 @@
+import type { ComponentConfig } from "@puckeditor/core";
+import { OrganigrammClient } from "./OrganigrammClient";
+
+export type OrganigrammProps = {
+  rootGroupId: number;
+  excludedRoles: string;
+  maxDepth: number;
+  maxVisibleMembers: number;
+  showPictures: boolean;
+};
+
+function Organigramm({
+  rootGroupId,
+  excludedRoles,
+  maxDepth,
+  maxVisibleMembers,
+  showPictures,
+}: OrganigrammProps) {
+  return (
+    <OrganigrammClient
+      rootGroupId={rootGroupId}
+      excludedRoles={excludedRoles}
+      maxDepth={maxDepth}
+      maxVisibleMembers={maxVisibleMembers}
+      showPictures={showPictures}
+    />
+  );
+}
+
+export const organigrammConfig: ComponentConfig<OrganigrammProps> = {
+  label: "Organigramm",
+  render: Organigramm,
+  defaultProps: {
+    rootGroupId: 0,
+    excludedRoles: "",
+    maxDepth: 3,
+    maxVisibleMembers: 4,
+    showPictures: true,
+  },
+  fields: {
+    rootGroupId: {
+      type: "number",
+      label: "Hitobito Gruppen-ID",
+      min: 1,
+    },
+    excludedRoles: {
+      type: "textarea",
+      label: "Ausgeschlossene Rollen",
+    },
+    maxDepth: {
+      type: "select",
+      label: "Maximale Tiefe",
+      options: [
+        { label: "1 Ebene", value: 1 },
+        { label: "2 Ebenen", value: 2 },
+        { label: "3 Ebenen", value: 3 },
+        { label: "4 Ebenen", value: 4 },
+        { label: "5 Ebenen", value: 5 },
+      ],
+    },
+    maxVisibleMembers: {
+      type: "select",
+      label: "Sichtbare Mitglieder",
+      options: [
+        { label: "3", value: 3 },
+        { label: "4", value: 4 },
+        { label: "5", value: 5 },
+        { label: "6", value: 6 },
+        { label: "8", value: 8 },
+        { label: "Alle", value: 99 },
+      ],
+    },
+    showPictures: {
+      type: "radio",
+      label: "Profilbilder anzeigen",
+      options: [
+        { label: "Ja", value: true },
+        { label: "Nein", value: false },
+      ],
+    },
+  },
+};

--- a/components/puck/OrganigrammClient.tsx
+++ b/components/puck/OrganigrammClient.tsx
@@ -1,0 +1,606 @@
+"use client";
+
+import cn from "@lib/cn";
+import type {
+  OrganigrammMember,
+  OrganigrammNode,
+  OrganigrammResponse,
+} from "@lib/hitobito/types";
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle, ChevronDown, ChevronRight, Users } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { HoverCard } from "radix-ui";
+import type { OrganigrammProps } from "./Organigramm";
+
+// ---------------------------------------------------------------------------
+// Data fetching & filtering
+// ---------------------------------------------------------------------------
+
+function useOrganigrammData(groupId: number) {
+  return useQuery<OrganigrammResponse>({
+    queryKey: ["organigramm", groupId],
+    queryFn: async () => {
+      const res = await fetch(`/api/organigramm?groupId=${groupId}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      return res.json();
+    },
+    enabled: groupId > 0,
+    staleTime: 60 * 60 * 1000,
+    retry: 1,
+  });
+}
+
+function parseExcludedRoles(excludedRoles: string): Set<string> {
+  if (!excludedRoles.trim()) return new Set();
+  return new Set(
+    excludedRoles
+      .split(",")
+      .map((r) => r.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function isRoleExcluded(member: OrganigrammMember, excluded: Set<string>): boolean {
+  if (excluded.size === 0) return false;
+  const roleTypeLower = member.role.toLowerCase();
+  const roleNameLower = (member.roleName ?? "").toLowerCase();
+  for (const pattern of excluded) {
+    if (roleTypeLower.includes(pattern) || roleNameLower === pattern) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function filterTree(
+  node: OrganigrammNode,
+  excluded: Set<string>
+): OrganigrammNode {
+  const filteredMembers = node.members.filter((m) => !isRoleExcluded(m, excluded));
+  const filteredChildren = node.children
+    .map((child) => filterTree(child, excluded))
+    .filter((child) => child.members.length > 0 || child.children.length > 0);
+  return { ...node, members: filteredMembers, children: filteredChildren };
+}
+
+/** Collect group IDs down to a given depth (for default expanded state). */
+function collectIds(node: OrganigrammNode, depth: number): number[] {
+  if (depth <= 0) return [];
+  const ids = [node.group.id];
+  for (const child of node.children) {
+    ids.push(...collectIds(child, depth - 1));
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Hover detail: avatar + member row (only shown in popover)
+// ---------------------------------------------------------------------------
+
+function getInitials(firstName: string, lastName: string): string {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}
+
+function stringToColor(str: string): string {
+  const colors = [
+    "bg-amber-600", "bg-emerald-600", "bg-sky-600", "bg-violet-600",
+    "bg-rose-600", "bg-teal-600", "bg-indigo-600", "bg-orange-600",
+  ];
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return colors[Math.abs(hash) % colors.length];
+}
+
+function MemberAvatar({
+  member,
+  showPicture,
+}: {
+  member: OrganigrammMember;
+  showPicture: boolean;
+}) {
+  const initials = getInitials(member.firstName, member.lastName);
+  const colorClass = stringToColor(`${member.firstName}${member.lastName}`);
+
+  if (showPicture && member.picture) {
+    return (
+      <div className="relative size-8 shrink-0 overflow-hidden rounded-full ring-1 ring-contrast-ground/20">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={member.picture}
+          alt={`${member.firstName} ${member.lastName}`}
+          className="size-full object-cover"
+          loading="lazy"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex size-8 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white ring-1 ring-contrast-ground/20",
+        colorClass
+      )}
+      aria-label={`${member.firstName} ${member.lastName}`}
+    >
+      {initials}
+    </div>
+  );
+}
+
+function HoverMemberRow({
+  member,
+  showPicture,
+}: {
+  member: OrganigrammMember;
+  showPicture: boolean;
+}) {
+  const displayName = member.nickname
+    ? `«${member.nickname}» ${member.firstName} ${member.lastName}`
+    : `${member.firstName} ${member.lastName}`;
+
+  return (
+    <div className="flex items-center gap-2 py-0.5">
+      <MemberAvatar member={member} showPicture={showPicture} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium leading-tight text-contrast-ground">
+          {displayName}
+        </p>
+        {member.roleName && (
+          <p className="truncate text-[10px] leading-tight text-contrast-ground/60">
+            {member.roleName}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compact group card (hierarchy-focused)
+// ---------------------------------------------------------------------------
+
+/** Get comma-separated scout names for display on the compact card. */
+function getScoutNames(members: OrganigrammMember[]): string {
+  if (members.length === 0) return "";
+  return members
+    .map((m) => m.nickname ?? m.firstName)
+    .join(", ");
+}
+
+function CompactCard({
+  node,
+  showPictures,
+  isExpanded,
+  onToggle,
+  className,
+}: {
+  node: OrganigrammNode;
+  showPictures: boolean;
+  isExpanded: boolean;
+  onToggle: (() => void) | null;
+  className?: string;
+}) {
+  const hasChildren = node.children.length > 0;
+  const scoutNames = getScoutNames(node.members);
+
+  const card = (
+    <div className={cn("flex w-28 flex-col rounded-lg border border-contrast-ground/20 bg-elevated px-2 py-1.5 text-center shadow-md transition-colors hover:border-contrast-ground/40 sm:w-36 sm:px-2.5 sm:py-2 lg:w-44 lg:px-3 lg:py-2.5", className)}>
+      {/* Content area */}
+      <div className="flex-1">
+        {/* Group name */}
+        <h3 className="text-[11px] font-semibold leading-tight text-contrast-ground sm:text-xs lg:text-sm">
+          {node.group.name}
+        </h3>
+
+        {/* Short name / subtitle */}
+        {node.group.shortName && node.group.shortName !== node.group.name && (
+          <p className="mt-0.5 text-[9px] leading-tight text-contrast-ground/60 sm:text-[10px] lg:text-[11px]">
+            {node.group.shortName}
+          </p>
+        )}
+
+        {/* Scout names (comma-separated) */}
+        {scoutNames && (
+          <p className="mt-1 text-[10px] leading-snug text-contrast-ground/70 sm:mt-1.5 sm:text-[11px] lg:text-xs">
+            {scoutNames}
+          </p>
+        )}
+      </div>
+
+      {/* Expand/collapse toggle — pinned to bottom */}
+      {hasChildren && onToggle && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggle();
+          }}
+          className="mx-auto mt-1.5 flex items-center gap-0.5 rounded-md border border-contrast-ground/15 px-1.5 py-0.5 text-[9px] text-contrast-ground/60 transition-colors hover:bg-contrast-ground/10 hover:text-contrast-ground sm:mt-2 sm:gap-1 sm:px-2 sm:text-[10px] lg:text-[11px]"
+        >
+          {isExpanded ? (
+            <ChevronDown className="size-2.5 shrink-0 sm:size-3" />
+          ) : (
+            <ChevronRight className="size-2.5 shrink-0 sm:size-3" />
+          )}
+          <span>
+            {node.children.length}{" "}
+            {node.children.length === 1 ? "Untergruppe" : "Untergruppen"}
+          </span>
+        </button>
+      )}
+    </div>
+  );
+
+  // Wrap in HoverCard if there are members to show
+  if (node.members.length === 0) return card;
+
+  return (
+    <HoverCard.Root openDelay={200} closeDelay={100}>
+      <HoverCard.Trigger asChild>{card}</HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content
+          side="bottom"
+          align="center"
+          sideOffset={8}
+          className="z-50 w-56 rounded-lg border border-contrast-ground/20 bg-elevated p-3 shadow-xl"
+        >
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-contrast-ground/60">
+            {node.group.name}
+          </p>
+          <div className="space-y-0.5">
+            {node.members.map((member) => (
+              <HoverMemberRow
+                key={`${member.id}-${member.role}`}
+                member={member}
+                showPicture={showPictures}
+              />
+            ))}
+          </div>
+          <HoverCard.Arrow className="fill-contrast-ground/20" />
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scale-to-fit container (prevents horizontal overflow on small screens)
+// ---------------------------------------------------------------------------
+
+/**
+ * Measures the natural width of its children and scales them down
+ * (via CSS transform) so they always fit the available container width.
+ * When the content fits naturally, scale = 1 and the content is centered.
+ * ResizeObserver watches both the container and the content so the scale
+ * updates on viewport resize AND on content changes (expand/collapse).
+ */
+function FitToWidth({ children }: { children: React.ReactNode }) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [layout, setLayout] = useState({ scale: 1, height: 0, offsetX: 0 });
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    const content = contentRef.current;
+    if (!wrapper || !content) return;
+
+    const update = () => {
+      const available = wrapper.clientWidth;
+      const natural = content.scrollWidth;
+      const naturalH = content.scrollHeight;
+      const s = available > 0 && natural > 0 ? Math.min(1, available / natural) : 1;
+      setLayout({
+        scale: s,
+        height: naturalH * s,
+        offsetX: (available - natural * s) / 2,
+      });
+    };
+
+    const ro = new ResizeObserver(update);
+    ro.observe(wrapper);
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className="w-full overflow-hidden"
+      style={{ height: layout.height || undefined }}
+    >
+      <div
+        ref={contentRef}
+        style={{
+          transform: `translate(${layout.offsetX}px, 0) scale(${layout.scale})`,
+          transformOrigin: "top left",
+          width: "fit-content",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tree layout with connector lines (responsive)
+// ---------------------------------------------------------------------------
+
+/** Connector line color — visible on both light and dark themes */
+const CONNECTOR = "bg-contrast-ground/40";
+
+/**
+ * CSS Grid layout for sibling nodes at the same tree level.
+ *
+ * Uses a 2-row grid so that Row 1 (connector + card) auto-sizes to the
+ * TALLEST cell — all cards' bottoms align regardless of content height.
+ * Row 2 holds each child's subtree (variable height, fine).
+ *
+ * Inside each Row 1 cell a `flex-1` spacer grows to fill the difference
+ * between the cell's natural height and the grid-auto row height, pushing
+ * the CompactCard to the bottom of the cell.
+ */
+function ChildrenGrid({
+  nodes,
+  showPictures,
+  expanded,
+  onToggle,
+}: {
+  nodes: OrganigrammNode[];
+  showPictures: boolean;
+  expanded: Set<number>;
+  onToggle: (id: number) => void;
+}) {
+  const count = nodes.length;
+
+  return (
+    <div
+      className="grid"
+      style={{
+        gridTemplateColumns: `repeat(${count}, auto)`,
+        gridTemplateRows: "auto auto",
+      }}
+    >
+      {/* --- Row 1: connector area + card for each sibling --- */}
+      {nodes.map((node, i) => {
+        const isFirst = i === 0;
+        const isLast = i === count - 1;
+        const isOnly = count === 1;
+        const hasChildren = node.children.length > 0;
+        const isExpanded = expanded.has(node.group.id);
+
+        return (
+          <div
+            key={`card-${node.group.id}`}
+            className="relative flex flex-col items-center px-0.5 pt-3 sm:px-1 sm:pt-4 lg:px-1.5 lg:pt-5"
+            style={{ gridRow: 1, gridColumn: i + 1 }}
+          >
+            {/* Vertical drop from horizontal bar down to card area */}
+            <div
+              className={cn(
+                "absolute left-1/2 top-0 h-3 w-0.5 -translate-x-1/2 sm:h-4 lg:h-5",
+                CONNECTOR
+              )}
+            />
+
+            {/* Left half of horizontal connector */}
+            {!isFirst && !isOnly && (
+              <div
+                className={cn(
+                  "absolute left-0 right-1/2 top-0 h-0.5",
+                  CONNECTOR
+                )}
+              />
+            )}
+
+            {/* Right half of horizontal connector */}
+            {!isLast && !isOnly && (
+              <div
+                className={cn(
+                  "absolute left-1/2 right-0 top-0 h-0.5",
+                  CONNECTOR
+                )}
+              />
+            )}
+
+            {/* Vertical connector: stretches from drop-line to card */}
+            <div className={cn("w-0.5 min-h-0 flex-1", CONNECTOR)} />
+
+            <CompactCard
+              node={node}
+              showPictures={showPictures}
+              isExpanded={isExpanded}
+              onToggle={hasChildren ? () => onToggle(node.group.id) : null}
+            />
+          </div>
+        );
+      })}
+
+      {/* --- Row 2: stem + recursive subtree for each child --- */}
+      {nodes.map((node, i) => {
+        const hasChildren = node.children.length > 0;
+        const isExpanded = expanded.has(node.group.id);
+
+        return (
+          <div
+            key={`sub-${node.group.id}`}
+            className="flex flex-col items-center"
+            style={{ gridRow: 2, gridColumn: i + 1 }}
+          >
+            {hasChildren && isExpanded && (
+              <>
+                {/* Vertical stem down from card to children */}
+                <div className={cn("h-3 w-0.5 sm:h-4 lg:h-5", CONNECTOR)} />
+                <ChildrenGrid
+                  nodes={node.children}
+                  showPictures={showPictures}
+                  expanded={expanded}
+                  onToggle={onToggle}
+                />
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function SkeletonCard() {
+  return (
+    <div className="w-28 animate-pulse rounded-lg border border-contrast-ground/20 bg-elevated px-2 py-1.5 text-center shadow-md sm:w-36 sm:px-2.5 sm:py-2 lg:w-44 lg:px-3 lg:py-2.5">
+      <div className="mx-auto h-3 w-14 rounded bg-contrast-ground/10 sm:h-4 sm:w-16 lg:w-20" />
+      <div className="mx-auto mt-1 h-2.5 w-10 rounded bg-contrast-ground/10 sm:h-3 sm:w-12 lg:w-16" />
+      <div className="mx-auto mt-1.5 h-2.5 w-20 rounded bg-contrast-ground/10 sm:mt-2 sm:h-3 sm:w-24 lg:w-28" />
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <FitToWidth>
+      <div className="flex flex-col items-center px-4">
+        <SkeletonCard />
+        <div className={cn("h-3 w-0.5 sm:h-4 lg:h-5", CONNECTOR)} />
+        <div className="flex justify-center gap-2 sm:gap-4 lg:gap-6">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+      </div>
+    </FitToWidth>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/** Number of tree levels to expand by default (root = level 1). */
+const DEFAULT_EXPANDED_DEPTH = 2;
+
+export function OrganigrammClient({
+  rootGroupId,
+  excludedRoles,
+  // maxDepth is used server-side in the API route, not client-side
+  showPictures,
+}: OrganigrammProps) {
+  const { data, isLoading, error } = useOrganigrammData(rootGroupId);
+
+  const excludedSet = useMemo(
+    () => parseExcludedRoles(excludedRoles),
+    [excludedRoles]
+  );
+
+  const filteredTree = useMemo(() => {
+    if (!data?.data) return null;
+    return filterTree(data.data, excludedSet);
+  }, [data, excludedSet]);
+
+  // Collapsible state — default: first 2 levels expanded
+  const defaultExpanded = useMemo(() => {
+    if (!filteredTree) return new Set<number>();
+    return new Set(collectIds(filteredTree, DEFAULT_EXPANDED_DEPTH));
+  }, [filteredTree]);
+
+  const [expanded, setExpanded] = useState<Set<number> | null>(null);
+
+  // Use default until user interacts
+  const activeExpanded = expanded ?? defaultExpanded;
+
+  const handleToggle = useCallback((id: number) => {
+    setExpanded((prev) => {
+      const current = prev ?? defaultExpanded;
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, [defaultExpanded]);
+
+  // --- Not configured ---
+  if (rootGroupId <= 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-contrast-ground/20 p-8 text-center">
+        <Users className="size-8 text-contrast-ground/60" />
+        <p className="text-sm text-contrast-ground/60">
+          Bitte Hitobito Gruppen-ID in den Komponenteneinstellungen konfigurieren.
+        </p>
+      </div>
+    );
+  }
+
+  // --- Loading ---
+  if (isLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  // --- Error ---
+  if (error || !filteredTree) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-lg border border-brand-red/30 bg-brand-red/10 p-6 text-center">
+        <AlertCircle className="size-6 text-brand-red" />
+        <p className="text-sm font-medium text-brand-red">
+          Organigramm konnte nicht geladen werden
+        </p>
+        <p className="text-xs text-contrast-ground/60">
+          {error instanceof Error ? error.message : "Unbekannter Fehler"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="full w-full py-4">
+      {/* Stale data indicator */}
+      {data?.stale && (
+        <p className="mb-3 text-center text-xs italic text-contrast-ground/60">
+          Zwischengespeicherte Daten (Hitobito nicht erreichbar)
+        </p>
+      )}
+
+      {/* Tree layout — scales down to fit on small screens */}
+      <FitToWidth>
+        <div className="flex flex-col items-center px-4 pb-2">
+          <CompactCard
+            node={filteredTree}
+            showPictures={showPictures}
+            isExpanded={activeExpanded.has(filteredTree.group.id)}
+            onToggle={
+              filteredTree.children.length > 0
+                ? () => handleToggle(filteredTree.group.id)
+                : null
+            }
+          />
+
+          {filteredTree.children.length > 0 &&
+            activeExpanded.has(filteredTree.group.id) && (
+              <>
+                {/* Vertical stem from root card to children grid */}
+                <div className={cn("h-3 w-0.5 sm:h-4 lg:h-5", CONNECTOR)} />
+                <ChildrenGrid
+                  nodes={filteredTree.children}
+                  showPictures={showPictures}
+                  expanded={activeExpanded}
+                  onToggle={handleToggle}
+                />
+              </>
+            )}
+        </div>
+      </FitToWidth>
+    </div>
+  );
+}

--- a/lib/config/page.config.ts
+++ b/lib/config/page.config.ts
@@ -15,6 +15,10 @@ import {
   multiColumnConfig,
 } from "@components/puck/MultiColumn";
 import {
+  OrganigrammProps,
+  organigrammConfig,
+} from "@components/puck/Organigramm";
+import {
   SectionDividerProps,
   sectionDividerConfig,
 } from "@components/puck/SectionDivider";
@@ -37,6 +41,7 @@ export type PageProps = {
   Hero: HeroProps;
   IFrame: IFrameProps;
   MultiColumn: MultiColumnProps;
+  Organigramm: OrganigrammProps;
   RichText: RichTextProps;
   SectionDivider: SectionDividerProps;
   VerticalSpace: VerticalSpaceProps;
@@ -60,6 +65,7 @@ export const pageConfig: PageConfig = sectionThemedConfig({
     Hero: heroConfig,
     IFrame: iframeConfig,
     MultiColumn: multiColumnConfig,
+    Organigramm: organigrammConfig,
     RichText: richTextConfig,
     SectionDivider: sectionDividerConfig,
     VerticalSpace: verticalSpaceConfig,

--- a/lib/db/db-mock-impl.ts
+++ b/lib/db/db-mock-impl.ts
@@ -1,5 +1,6 @@
 import { defaultFooterData } from "@lib/config/footer.config";
 import { defaultNavbarData } from "@lib/config/navbar.config";
+import type { OrganigrammCache } from "@lib/hitobito/types";
 import { defaultSecurityConfig } from "@lib/security/security-config";
 import type {
   Product,
@@ -223,5 +224,19 @@ export class MockDatabaseService implements DatabaseService {
 
   async markSessionProcessed(sessionId: string): Promise<void> {
     this.processedSessions.add(sessionId);
+  }
+
+  // --- Hitobito Organigramm cache ---
+
+  private organigrammCache = new Map<number, OrganigrammCache>();
+
+  async getOrganigrammCache(
+    rootGroupId: number
+  ): Promise<OrganigrammCache | null> {
+    return this.organigrammCache.get(rootGroupId) ?? null;
+  }
+
+  async saveOrganigrammCache(cache: OrganigrammCache): Promise<void> {
+    this.organigrammCache.set(cache.rootGroupId, cache);
   }
 }

--- a/lib/db/db.ts
+++ b/lib/db/db.ts
@@ -2,6 +2,7 @@ import type { FooterData } from "@lib/config/footer.config";
 import type { NavbarData } from "@lib/config/navbar.config";
 import type { PageData } from "@lib/config/page.config";
 import { env } from "@lib/env";
+import type { OrganigrammCache } from "@lib/hitobito/types";
 import type { SecurityConfig } from "@lib/security/security-config";
 import type { Product, ProductInput, ShopSettings } from "@lib/shop/types";
 import type { FileRecord, FileRecordInput } from "@lib/storage/file-record";
@@ -63,6 +64,11 @@ export interface DatabaseService {
   // Webhook idempotency
   isSessionProcessed(sessionId: string): Promise<boolean>;
   markSessionProcessed(sessionId: string): Promise<void>;
+  // Hitobito Organigramm cache
+  getOrganigrammCache(
+    rootGroupId: number
+  ): Promise<OrganigrammCache | null>;
+  saveOrganigrammCache(cache: OrganigrammCache): Promise<void>;
 }
 
 function getDatabaseService(): DatabaseService {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -26,6 +26,9 @@ export const env = createEnv({
     S3_ACCESS_KEY_ID: z.string().optional(),
     S3_SECRET_ACCESS_KEY: z.string().optional(),
     S3_PUBLIC_URL: z.string().optional(),
+    // Hitobito (MiData) API
+    HITOBITO_BASE_URL: z.string().optional(),
+    HITOBITO_API_TOKEN: z.string().optional(),
   },
   client: {
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
@@ -56,6 +59,9 @@ export const env = createEnv({
     S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID,
     S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY,
     S3_PUBLIC_URL: process.env.S3_PUBLIC_URL,
+    // Hitobito (MiData) API
+    HITOBITO_BASE_URL: process.env.HITOBITO_BASE_URL,
+    HITOBITO_API_TOKEN: process.env.HITOBITO_API_TOKEN,
   },
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
   emptyStringAsUndefined: true,
@@ -81,6 +87,18 @@ export const env = createEnv({
           code: z.ZodIssueCode.custom,
           message:
             "STRIPE_WEBHOOK_SECRET is required when STRIPE_SECRET_KEY is configured",
+        });
+      }
+
+      // Hitobito: both URL and token required together
+      if (
+        (v.HITOBITO_BASE_URL && !v.HITOBITO_API_TOKEN) ||
+        (!v.HITOBITO_BASE_URL && v.HITOBITO_API_TOKEN)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "HITOBITO_BASE_URL and HITOBITO_API_TOKEN must both be set together",
         });
       }
     }),

--- a/lib/hitobito/api/client.ts
+++ b/lib/hitobito/api/client.ts
@@ -1,0 +1,482 @@
+import {
+  NotFoundError,
+  RateLimitError,
+  UnauthorizedError,
+  ValidationError,
+} from "./errors";
+import {
+  EventKindCategoriesResponseSchema,
+  EventKindCategorySchema,
+  EventKindSchema,
+  EventKindsResponseSchema,
+  EventSchema,
+  EventsResponseSchema,
+  GroupSchema,
+  GroupsResponseSchema,
+  InvoiceSchema,
+  InvoicesResponseSchema,
+  MailingListSchema,
+  MailingListsResponseSchema,
+  PeopleResponseSchema,
+  PersonSchema,
+  RoleSchema,
+  RolesResponseSchema,
+} from "./schemas";
+import type {
+  Event,
+  EventKind,
+  EventKindCategory,
+  EventsFilter,
+  EventsSortKey,
+  Group,
+  GroupsFilter,
+  GroupsSortKey,
+  HitobitoClientConfig,
+  Invoice,
+  InvoiceUpdate,
+  InvoicesFilter,
+  InvoicesSortKey,
+  MailingList,
+  MailingListsFilter,
+  MailingListsSortKey,
+  PeopleFilter,
+  PeopleSortKey,
+  Person,
+  PersonUpdate,
+  QueryOptions,
+  Role,
+  RoleCreate,
+  RoleUpdate,
+  RolesFilter,
+  RolesSortKey,
+} from "./types";
+
+export class HitobitoClient {
+  private baseUrl: string;
+  private token: string;
+
+  constructor(config: HitobitoClientConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, "");
+    this.token = config.token;
+  }
+
+  private async request<T>(
+    path: string,
+    options: { method?: string; body?: unknown } = {}
+  ): Promise<T> {
+    const { method = "GET", body } = options;
+
+    const fetchOptions: RequestInit = {
+      method,
+      headers: {
+        "X-Token": this.token,
+        Accept: "application/json",
+        "Content-Type": "application/vnd.api+json",
+      },
+    };
+
+    if (body !== undefined) {
+      fetchOptions.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(`${this.baseUrl}/api${path}`, fetchOptions);
+
+    if (response.status === 401) {
+      throw new UnauthorizedError();
+    }
+
+    if (response.status === 403) {
+      throw new UnauthorizedError("Forbidden: Access denied");
+    }
+
+    if (response.status === 404) {
+      throw new NotFoundError();
+    }
+
+    if (response.status === 429) {
+      throw new RateLimitError();
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private buildQuery(
+    options?: QueryOptions<Record<string, unknown>, string>
+  ): string {
+    if (!options) return "";
+
+    const params = new URLSearchParams();
+
+    if (options.filter) {
+      for (const [key, value] of Object.entries(options.filter)) {
+        if (value !== undefined) {
+          params.set(`filter[${key}]`, String(value));
+        }
+      }
+    }
+
+    if (options.sort) {
+      params.set("sort", options.sort);
+    }
+
+    if (options.page !== undefined) {
+      params.set("page[number]", String(options.page));
+    }
+
+    if (options.per_page !== undefined) {
+      params.set("page[size]", String(options.per_page));
+    }
+
+    const qs = params.toString();
+    return qs ? `?${qs}` : "";
+  }
+
+  async getPerson(id: number): Promise<Person> {
+    const data = await this.request<unknown>(`/people/${id}`);
+    const parsed = PersonSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid person response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getGroup(id: number): Promise<Group> {
+    const data = await this.request<unknown>(`/groups/${id}`);
+    const parsed = GroupSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid group response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getEvent(id: number): Promise<Event> {
+    const data = await this.request<unknown>(`/events/${id}`);
+    const parsed = EventSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid event response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getRole(id: number): Promise<Role> {
+    const data = await this.request<unknown>(`/roles/${id}`);
+    const parsed = RoleSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid role response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getInvoice(id: number): Promise<Invoice> {
+    const data = await this.request<unknown>(`/invoices/${id}`);
+    const parsed = InvoiceSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid invoice response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getMailingList(id: number): Promise<MailingList> {
+    const data = await this.request<unknown>(`/mailing_lists/${id}`);
+    const parsed = MailingListSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid mailing list response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getEventKind(id: number): Promise<EventKind> {
+    const data = await this.request<unknown>(`/event_kinds/${id}`);
+    const parsed = EventKindSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid event kind response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getEventKindCategory(id: number): Promise<EventKindCategory> {
+    const data = await this.request<unknown>(`/event_kind_categories/${id}`);
+    const parsed = EventKindCategorySchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid event kind category response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getPeople(
+    options?: QueryOptions<PeopleFilter, PeopleSortKey>
+  ): Promise<Person[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/people${qs}`);
+    const parsed = PeopleResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid people response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getGroups(
+    options?: QueryOptions<GroupsFilter, GroupsSortKey>
+  ): Promise<Group[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/groups${qs}`);
+    const parsed = GroupsResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid groups response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getEvents(
+    options?: QueryOptions<EventsFilter, EventsSortKey>
+  ): Promise<Event[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/events${qs}`);
+    const parsed = EventsResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid events response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getRoles(
+    options?: QueryOptions<RolesFilter, RolesSortKey>
+  ): Promise<Role[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/roles${qs}`);
+    const parsed = RolesResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid roles response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getInvoices(
+    options?: QueryOptions<InvoicesFilter, InvoicesSortKey>
+  ): Promise<Invoice[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/invoices${qs}`);
+    const parsed = InvoicesResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid invoices response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getMailingLists(
+    options?: QueryOptions<MailingListsFilter, MailingListsSortKey>
+  ): Promise<MailingList[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/mailing_lists${qs}`);
+    const parsed = MailingListsResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid mailing lists response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getEventKinds(options?: QueryOptions): Promise<EventKind[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/event_kinds${qs}`);
+    const parsed = EventKindsResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid event kinds response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async getEventKindCategories(
+    options?: QueryOptions
+  ): Promise<EventKindCategory[]> {
+    const qs = this.buildQuery(
+      options as QueryOptions<Record<string, unknown>, string>
+    );
+    const data = await this.request<unknown>(`/event_kind_categories${qs}`);
+    const parsed = EventKindCategoriesResponseSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid event kind categories response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async updatePerson(id: number, attrs: PersonUpdate): Promise<Person> {
+    const body = {
+      data: {
+        id: String(id),
+        type: "people",
+        attributes: attrs,
+      },
+    };
+    const data = await this.request<unknown>(`/people/${id}`, {
+      method: "PATCH",
+      body,
+    });
+    const parsed = PersonSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid person response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async createRole(attrs: RoleCreate): Promise<Role> {
+    const body = {
+      data: {
+        type: "roles",
+        attributes: attrs,
+      },
+    };
+    const data = await this.request<unknown>("/roles", {
+      method: "POST",
+      body,
+    });
+    const parsed = RoleSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid role response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async updateRole(id: number, attrs: RoleUpdate): Promise<Role> {
+    const body = {
+      data: {
+        id: String(id),
+        type: "roles",
+        attributes: attrs,
+      },
+    };
+    const data = await this.request<unknown>(`/roles/${id}`, {
+      method: "PATCH",
+      body,
+    });
+    const parsed = RoleSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid role response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+
+  async deleteRole(id: number): Promise<void> {
+    await this.request<void>(`/roles/${id}`, { method: "DELETE" });
+  }
+
+  async updateInvoice(id: number, attrs: InvoiceUpdate): Promise<Invoice> {
+    const body = {
+      data: {
+        id: String(id),
+        type: "invoices",
+        attributes: attrs,
+      },
+    };
+    const data = await this.request<unknown>(`/invoices/${id}`, {
+      method: "PATCH",
+      body,
+    });
+    const parsed = InvoiceSchema.safeParse(data);
+
+    if (!parsed.success) {
+      throw new ValidationError(
+        `Invalid invoice response: ${parsed.error.message}`
+      );
+    }
+
+    return parsed.data;
+  }
+}

--- a/lib/hitobito/api/errors.ts
+++ b/lib/hitobito/api/errors.ts
@@ -1,0 +1,37 @@
+export class HitobitoError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number
+  ) {
+    super(message);
+    this.name = "HitobitoError";
+  }
+}
+
+export class UnauthorizedError extends HitobitoError {
+  constructor(message = "Unauthorized: Invalid or missing API token") {
+    super(message, 401);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class NotFoundError extends HitobitoError {
+  constructor(message = "Resource not found") {
+    super(message, 404);
+    this.name = "NotFoundError";
+  }
+}
+
+export class RateLimitError extends HitobitoError {
+  constructor(message = "Rate limit exceeded") {
+    super(message, 429);
+    this.name = "RateLimitError";
+  }
+}
+
+export class ValidationError extends HitobitoError {
+  constructor(message: string) {
+    super(message, 422);
+    this.name = "ValidationError";
+  }
+}

--- a/lib/hitobito/api/index.ts
+++ b/lib/hitobito/api/index.ts
@@ -1,0 +1,4 @@
+export { HitobitoClient } from "./client";
+export * from "./types";
+export * from "./errors";
+export * from "./schemas";

--- a/lib/hitobito/api/schemas.ts
+++ b/lib/hitobito/api/schemas.ts
@@ -1,0 +1,419 @@
+import { z } from "zod";
+
+const PersonAttributesSchema = z.object({
+  first_name: z.string(),
+  last_name: z.string(),
+  nickname: z.string().nullable().optional(),
+  email: z.string().nullable().optional(),
+  birthday: z.string().nullable().optional(),
+  gender: z.enum(["m", "w"]).nullable().optional(),
+  address: z.string().nullable().optional(),
+  zip_code: z.coerce.string().nullable().optional(),
+  town: z.string().nullable().optional(),
+  country: z.string().nullable().optional(),
+  primary_group_id: z.coerce.number().nullable().optional(),
+  picture: z.string().nullable().optional(),
+});
+
+const GroupAttributesSchema = z.object({
+  name: z.string(),
+  short_name: z.string().nullable().optional(),
+  type: z.string().optional(),
+  parent_id: z.coerce.number().nullable().optional(),
+  layer_group_id: z.coerce.number().nullable().optional(),
+  email: z.string().nullable().optional(),
+  address: z.string().nullable().optional(),
+  zip_code: z.coerce.string().nullable().optional(),
+  town: z.string().nullable().optional(),
+  country: z.string().nullable().optional(),
+});
+
+const EventAttributesSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  motto: z.string().nullable().optional(),
+  cost: z.string().nullable().optional(),
+  maximum_participants: z.coerce.number().nullable().optional(),
+  participant_count: z.coerce.number().nullable().optional(),
+  location: z.string().nullable().optional(),
+  application_opening_at: z.string().nullable().optional(),
+  application_closing_at: z.string().nullable().optional(),
+  application_conditions: z.string().nullable().optional(),
+  state: z.string().nullable().optional(),
+  group_ids: z.array(z.coerce.number()).optional(),
+});
+
+const EventDateAttributesSchema = z.object({
+  label: z.string().nullable().optional(),
+  start_at: z.string(),
+  finish_at: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+});
+
+const RelationshipField = z
+  .object({
+    data: z
+      .array(z.object({ id: z.coerce.number(), type: z.string() }))
+      .optional(),
+  })
+  .passthrough();
+
+const EventRelationshipSchema = z
+  .object({
+    dates: RelationshipField.optional(),
+    groups: RelationshipField.optional(),
+  })
+  .passthrough();
+
+const IncludedResourceSchema = z.object({
+  id: z.coerce.number(),
+  type: z.string(),
+  attributes: z.record(z.string(), z.unknown()),
+});
+
+const RoleAttributesSchema = z.object({
+  type: z.string().optional(),
+  name: z.string().optional(),
+  person_id: z.coerce.number().optional(),
+  group_id: z.coerce.number().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  deleted_at: z.string().nullable().optional(),
+});
+
+const InvoiceAttributesSchema = z.object({
+  title: z.string(),
+  state: z.string(),
+  sequence_number: z.string().nullable().optional(),
+  recipient_email: z.string().nullable().optional(),
+  recipient_address: z.string().nullable().optional(),
+  sent_at: z.string().nullable().optional(),
+  due_at: z.string().nullable().optional(),
+  total: z.string().nullable().optional(),
+  amount_open: z.string().nullable().optional(),
+  group_id: z.coerce.number().nullable().optional(),
+  recipient_id: z.coerce.number().nullable().optional(),
+});
+
+const MailingListAttributesSchema = z.object({
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  publisher: z.string().nullable().optional(),
+  mail_name: z.string().nullable().optional(),
+  additional_sender: z.string().nullable().optional(),
+  subscribable: z.boolean().nullable().optional(),
+  subscribers_may_post: z.boolean().nullable().optional(),
+  anyone_may_post: z.boolean().nullable().optional(),
+  group_id: z.coerce.number().nullable().optional(),
+});
+
+const EventKindAttributesSchema = z.object({
+  label: z.string(),
+  short_name: z.string().nullable().optional(),
+  minimum_age: z.coerce.number().nullable().optional(),
+  general_information: z.string().nullable().optional(),
+  application_conditions: z.string().nullable().optional(),
+});
+
+const EventKindCategoryAttributesSchema = z.object({
+  label: z.string(),
+  order: z.coerce.number().nullable().optional(),
+});
+
+export const PersonSchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.literal("people"),
+      attributes: PersonAttributesSchema,
+    }),
+  })
+  .transform((val) => ({
+    id: val.data.id,
+    ...val.data.attributes,
+  }));
+
+export const GroupSchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.literal("groups"),
+      attributes: GroupAttributesSchema,
+    }),
+  })
+  .transform((val) => ({
+    id: val.data.id,
+    type: val.data.type,
+    ...val.data.attributes,
+  }));
+
+export const EventSchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.string(),
+      attributes: EventAttributesSchema,
+      relationships: EventRelationshipSchema.optional(),
+    }),
+    included: z.array(IncludedResourceSchema).optional(),
+  })
+  .transform((val) => {
+    const group_ids =
+      val.data.attributes.group_ids ??
+      val.data.relationships?.groups?.data?.map((g) => g.id) ??
+      [];
+    const dateIds = new Set(
+      val.data.relationships?.dates?.data?.map((d) => d.id) ?? []
+    );
+    const dates = (val.included ?? [])
+      .filter((inc) => inc.type === "event_dates" && dateIds.has(inc.id))
+      .map((inc) => ({
+        id: inc.id,
+        ...EventDateAttributesSchema.parse(inc.attributes),
+      }));
+
+    const { group_ids: _discardAttrGroupIds, ...restAttrs } =
+      val.data.attributes;
+    return {
+      id: val.data.id,
+      ...restAttrs,
+      dates,
+      group_ids,
+    };
+  });
+
+export const RoleSchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.literal("roles"),
+      attributes: RoleAttributesSchema,
+    }),
+  })
+  .transform((val) => ({
+    id: val.data.id,
+    type: val.data.attributes.type || "",
+    name: val.data.attributes.name,
+    person_id: val.data.attributes.person_id || 0,
+    group_id: val.data.attributes.group_id || 0,
+    created_at: val.data.attributes.created_at || "",
+    updated_at: val.data.attributes.updated_at || "",
+    deleted_at: val.data.attributes.deleted_at,
+  }));
+
+export const InvoiceSchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.literal("invoices"),
+      attributes: InvoiceAttributesSchema,
+    }),
+  })
+  .transform((val) => ({
+    id: val.data.id,
+    ...val.data.attributes,
+  }));
+
+export const MailingListSchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.literal("mailing_lists"),
+      attributes: MailingListAttributesSchema,
+    }),
+  })
+  .transform((val) => ({
+    id: val.data.id,
+    ...val.data.attributes,
+  }));
+
+export const EventKindSchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.literal("event_kinds"),
+      attributes: EventKindAttributesSchema,
+    }),
+  })
+  .transform((val) => ({
+    id: val.data.id,
+    ...val.data.attributes,
+  }));
+
+export const EventKindCategorySchema = z
+  .object({
+    data: z.object({
+      id: z.coerce.number(),
+      type: z.literal("event_kind_categories"),
+      attributes: EventKindCategoryAttributesSchema,
+    }),
+  })
+  .transform((val) => ({
+    id: val.data.id,
+    ...val.data.attributes,
+  }));
+
+export const PeopleResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.literal("people"),
+        attributes: PersonAttributesSchema,
+      })
+    ),
+  })
+  .transform((val) =>
+    val.data.map((item) => ({
+      id: item.id,
+      ...item.attributes,
+    }))
+  );
+
+export const GroupsResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.literal("groups"),
+        attributes: GroupAttributesSchema,
+      })
+    ),
+  })
+  .transform((val) =>
+    val.data.map((item) => ({
+      id: item.id,
+      type: item.type,
+      ...item.attributes,
+    }))
+  );
+
+export const EventsResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.string(),
+        attributes: EventAttributesSchema,
+        relationships: EventRelationshipSchema.optional(),
+      })
+    ),
+    included: z.array(IncludedResourceSchema).optional(),
+  })
+  .transform((val) =>
+    val.data.map((item) => {
+      const group_ids =
+        item.attributes.group_ids ??
+        item.relationships?.groups?.data?.map((g) => g.id) ??
+        [];
+      const dateIds = new Set(
+        item.relationships?.dates?.data?.map((d) => d.id) ?? []
+      );
+      const dates = (val.included ?? [])
+        .filter((inc) => inc.type === "event_dates" && dateIds.has(inc.id))
+        .map((inc) => ({
+          id: inc.id,
+          ...EventDateAttributesSchema.parse(inc.attributes),
+        }));
+
+      const { group_ids: _discardAttrGroupIds, ...restAttrs } =
+        item.attributes;
+      return {
+        id: item.id,
+        ...restAttrs,
+        dates,
+        group_ids,
+      };
+    })
+  );
+
+export const RolesResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.literal("roles"),
+        attributes: RoleAttributesSchema,
+      })
+    ),
+  })
+  .transform((val) =>
+    val.data.map((item) => ({
+      id: item.id,
+      type: item.attributes.type || "",
+      name: item.attributes.name,
+      person_id: item.attributes.person_id || 0,
+      group_id: item.attributes.group_id || 0,
+      created_at: item.attributes.created_at || "",
+      updated_at: item.attributes.updated_at || "",
+      deleted_at: item.attributes.deleted_at,
+    }))
+  );
+
+export const InvoicesResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.literal("invoices"),
+        attributes: InvoiceAttributesSchema,
+      })
+    ),
+  })
+  .transform((val) =>
+    val.data.map((item) => ({
+      id: item.id,
+      ...item.attributes,
+    }))
+  );
+
+export const MailingListsResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.literal("mailing_lists"),
+        attributes: MailingListAttributesSchema,
+      })
+    ),
+  })
+  .transform((val) =>
+    val.data.map((item) => ({
+      id: item.id,
+      ...item.attributes,
+    }))
+  );
+
+export const EventKindsResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.literal("event_kinds"),
+        attributes: EventKindAttributesSchema,
+      })
+    ),
+  })
+  .transform((val) =>
+    val.data.map((item) => ({
+      id: item.id,
+      ...item.attributes,
+    }))
+  );
+
+export const EventKindCategoriesResponseSchema = z
+  .object({
+    data: z.array(
+      z.object({
+        id: z.coerce.number(),
+        type: z.literal("event_kind_categories"),
+        attributes: EventKindCategoryAttributesSchema,
+      })
+    ),
+  })
+  .transform((val) =>
+    val.data.map((item) => ({
+      id: item.id,
+      ...item.attributes,
+    }))
+  );

--- a/lib/hitobito/api/types.ts
+++ b/lib/hitobito/api/types.ts
@@ -1,0 +1,211 @@
+export interface HitobitoClientConfig {
+  baseUrl: string;
+  token: string;
+}
+
+export interface Person {
+  id: number;
+  first_name: string;
+  last_name: string;
+  nickname?: string | null;
+  email?: string | null;
+  birthday?: string | null;
+  gender?: "m" | "w" | null;
+  address?: string | null;
+  zip_code?: string | null;
+  town?: string | null;
+  country?: string | null;
+  primary_group_id?: number | null;
+  picture?: string | null;
+}
+
+export interface Group {
+  id: number;
+  name: string;
+  short_name?: string | null;
+  type: string;
+  parent_id?: number | null;
+  layer_group_id?: number | null;
+  email?: string | null;
+  address?: string | null;
+  zip_code?: string | null;
+  town?: string | null;
+  country?: string | null;
+}
+
+export interface Event {
+  id: number;
+  name: string;
+  description?: string | null;
+  motto?: string | null;
+  cost?: string | null;
+  maximum_participants?: number | null;
+  participant_count?: number | null;
+  location?: string | null;
+  application_opening_at?: string | null;
+  application_closing_at?: string | null;
+  application_conditions?: string | null;
+  state?: string | null;
+  dates: EventDate[];
+  group_ids: number[];
+}
+
+export interface EventDate {
+  id: number;
+  label?: string | null;
+  start_at: string;
+  finish_at?: string | null;
+  location?: string | null;
+}
+
+export interface Role {
+  id: number;
+  type: string;
+  name?: string;
+  person_id: number;
+  group_id: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at?: string | null;
+}
+
+export interface Invoice {
+  id: number;
+  title: string;
+  state: string;
+  sequence_number?: string | null;
+  recipient_email?: string | null;
+  recipient_address?: string | null;
+  sent_at?: string | null;
+  due_at?: string | null;
+  total?: string | null;
+  amount_open?: string | null;
+  group_id?: number | null;
+  recipient_id?: number | null;
+}
+
+export interface MailingList {
+  id: number;
+  name: string;
+  description?: string | null;
+  publisher?: string | null;
+  mail_name?: string | null;
+  additional_sender?: string | null;
+  subscribable?: boolean | null;
+  subscribers_may_post?: boolean | null;
+  anyone_may_post?: boolean | null;
+  group_id?: number | null;
+}
+
+export interface EventKind {
+  id: number;
+  label: string;
+  short_name?: string | null;
+  minimum_age?: number | null;
+  general_information?: string | null;
+  application_conditions?: string | null;
+}
+
+export interface EventKindCategory {
+  id: number;
+  label: string;
+  order?: number | null;
+}
+
+export interface PeopleFilter {
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  company?: string;
+  birthday?: string;
+  gender?: string;
+  primary_group_id?: number;
+}
+
+export interface GroupsFilter {
+  name?: string;
+  type?: string;
+  parent_id?: number;
+  layer?: string;
+  archived_at?: string;
+}
+
+export interface EventsFilter {
+  type?: string;
+  group_id?: number;
+  kind_id?: number;
+  state?: string;
+  number?: string;
+}
+
+export interface RolesFilter {
+  person_id?: number;
+  group_id?: number;
+  type?: string;
+  label?: string;
+  start_on?: string;
+  end_on?: string;
+}
+
+export interface InvoicesFilter {
+  group_id?: number;
+  recipient_id?: number;
+}
+
+export interface MailingListsFilter {
+  group_id?: number;
+  subscribers_may_post?: boolean;
+  anyone_may_post?: boolean;
+}
+
+export type PeopleSortKey = "last_name" | "first_name" | "email";
+export type GroupsSortKey = "name" | "type";
+export type EventsSortKey = "name" | "state";
+export type RolesSortKey = "type" | "created_at";
+export type InvoicesSortKey =
+  | "title"
+  | "state"
+  | "due_at"
+  | "sequence_number";
+export type MailingListsSortKey = "name";
+
+export interface QueryOptions<
+  TFilter = Record<string, unknown>,
+  TSort extends string = string,
+> {
+  filter?: TFilter;
+  sort?: TSort;
+  page?: number;
+  per_page?: number;
+}
+
+export interface PersonUpdate {
+  first_name?: string;
+  last_name?: string;
+  nickname?: string | null;
+  email?: string | null;
+  birthday?: string | null;
+  gender?: "m" | "w" | null;
+  address?: string | null;
+  zip_code?: string | null;
+  town?: string | null;
+  country?: string | null;
+}
+
+export interface RoleCreate {
+  type: string;
+  person_id: number;
+  group_id: number;
+  label?: string;
+}
+
+export interface RoleUpdate {
+  type?: string;
+  label?: string;
+}
+
+export interface InvoiceUpdate {
+  title?: string;
+  state?: string;
+  due_at?: string | null;
+}

--- a/lib/hitobito/client.ts
+++ b/lib/hitobito/client.ts
@@ -1,0 +1,16 @@
+import { env } from "@lib/env";
+import { HitobitoClient } from "./api";
+
+function getHitobitoClient(): HitobitoClient | null {
+  const baseUrl = env.HITOBITO_BASE_URL;
+  const token = env.HITOBITO_API_TOKEN;
+  if (!baseUrl || !token) return null;
+  return new HitobitoClient({ baseUrl, token });
+}
+
+/**
+ * Hitobito API client instance. Null when HITOBITO_BASE_URL/HITOBITO_API_TOKEN
+ * are not configured. Check for null before using to gracefully disable
+ * Hitobito-dependent features (e.g. Organigramm).
+ */
+export const hitobitoClient = getHitobitoClient();

--- a/lib/hitobito/fetch-organigramm.ts
+++ b/lib/hitobito/fetch-organigramm.ts
@@ -1,0 +1,182 @@
+import type { HitobitoClient } from "./api";
+import type { Group, Person, Role } from "./api/types";
+import type { OrganigrammMember, OrganigrammNode } from "./types";
+
+/** Max concurrent Hitobito API requests to avoid rate limiting */
+const CONCURRENCY_LIMIT = 5;
+
+/**
+ * Execute an array of async functions with a concurrency limit.
+ * Returns results in the same order as the input.
+ */
+async function parallelLimit<T>(
+  tasks: (() => Promise<T>)[],
+  limit: number
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex++;
+      results[index] = await tasks[index]();
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(limit, tasks.length) },
+    () => worker()
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Extract a human-readable role name from the Hitobito role type string.
+ * e.g. "Group::Abteilung::Abteilungsleitung" → "Abteilungsleitung"
+ */
+function extractRoleName(roleType: string): string {
+  const parts = roleType.split("::");
+  return parts[parts.length - 1] ?? roleType;
+}
+
+/**
+ * Recursively fetch the group tree from Hitobito starting at the given root group.
+ * For each group, fetches roles and resolves person details.
+ *
+ * @param client - Hitobito API client
+ * @param rootGroupId - The group ID to start from
+ * @param maxDepth - Maximum depth to traverse (1 = root only)
+ */
+export async function fetchOrganigramm(
+  client: HitobitoClient,
+  rootGroupId: number,
+  maxDepth: number = 5
+): Promise<OrganigrammNode> {
+  // Phase 1: Build group tree (BFS by level)
+  const rootGroup = await client.getGroup(rootGroupId);
+  const groupMap = new Map<number, Group>();
+  const childrenMap = new Map<number, number[]>();
+  groupMap.set(rootGroup.id, rootGroup);
+  childrenMap.set(rootGroup.id, []);
+
+  let currentLevel = [rootGroup.id];
+  let depth = 1;
+
+  while (currentLevel.length > 0 && depth < maxDepth) {
+    const nextLevel: number[] = [];
+
+    // Fetch children for all groups at this level in parallel
+    const childFetches = currentLevel.map(
+      (parentId) => () =>
+        client
+          .getGroups({ filter: { parent_id: parentId } })
+          .catch(() => [] as Group[])
+    );
+    const childResults = await parallelLimit(childFetches, CONCURRENCY_LIMIT);
+
+    for (let i = 0; i < currentLevel.length; i++) {
+      const parentId = currentLevel[i];
+      const children = childResults[i] ?? [];
+
+      for (const child of children) {
+        groupMap.set(child.id, child);
+        childrenMap.set(child.id, []);
+        const parentChildren = childrenMap.get(parentId);
+        if (parentChildren) {
+          parentChildren.push(child.id);
+        }
+        nextLevel.push(child.id);
+      }
+    }
+
+    currentLevel = nextLevel;
+    depth++;
+  }
+
+  // Phase 2: Fetch roles for all groups in parallel
+  const allGroupIds = [...groupMap.keys()];
+  const roleFetches = allGroupIds.map(
+    (groupId) => () =>
+      client
+        .getRoles({ filter: { group_id: groupId } })
+        .catch(() => [] as Role[])
+  );
+  const roleResults = await parallelLimit(roleFetches, CONCURRENCY_LIMIT);
+
+  // Map group ID → roles
+  const groupRolesMap = new Map<number, Role[]>();
+  for (let i = 0; i < allGroupIds.length; i++) {
+    const roles = (roleResults[i] ?? []).filter((r) => !r.deleted_at);
+    groupRolesMap.set(allGroupIds[i], roles);
+  }
+
+  // Phase 3: Collect unique person IDs and fetch their details
+  const personIds = new Set<number>();
+  for (const roles of groupRolesMap.values()) {
+    for (const role of roles) {
+      if (role.person_id) {
+        personIds.add(role.person_id);
+      }
+    }
+  }
+
+  const personIdArray = [...personIds];
+  const personFetches = personIdArray.map(
+    (id) => () =>
+      client.getPerson(id).catch(() => null as Person | null)
+  );
+  const personResults = await parallelLimit(personFetches, CONCURRENCY_LIMIT);
+
+  const personMap = new Map<number, Person>();
+  for (let i = 0; i < personIdArray.length; i++) {
+    const person = personResults[i];
+    if (person) {
+      personMap.set(person.id, person);
+    }
+  }
+
+  // Phase 4: Assemble the tree
+  function buildNode(groupId: number): OrganigrammNode {
+    const group = groupMap.get(groupId)!;
+    const roles = groupRolesMap.get(groupId) ?? [];
+    const childIds = childrenMap.get(groupId) ?? [];
+
+    // Build members list from roles
+    const members: OrganigrammMember[] = [];
+    const seenPersonIds = new Set<number>();
+
+    for (const role of roles) {
+      // Skip duplicates (same person might have multiple roles in same group)
+      // Keep first occurrence (typically the most relevant role)
+      if (seenPersonIds.has(role.person_id)) continue;
+      seenPersonIds.add(role.person_id);
+
+      const person = personMap.get(role.person_id);
+      if (!person) continue;
+
+      members.push({
+        id: person.id,
+        firstName: person.first_name,
+        lastName: person.last_name,
+        nickname: person.nickname,
+        role: role.type,
+        roleName: role.name ?? extractRoleName(role.type),
+        picture: person.picture,
+      });
+    }
+
+    return {
+      group: {
+        id: group.id,
+        name: group.name,
+        shortName: group.short_name,
+        type: group.type,
+      },
+      members,
+      children: childIds.map(buildNode),
+    };
+  }
+
+  return buildNode(rootGroupId);
+}

--- a/lib/hitobito/types.ts
+++ b/lib/hitobito/types.ts
@@ -1,0 +1,39 @@
+/** A single member within a group in the Organigramm */
+export interface OrganigrammMember {
+  id: number;
+  firstName: string;
+  lastName: string;
+  nickname?: string | null;
+  /** Role type string from Hitobito (e.g. "Group::Abteilungsleitung") */
+  role: string;
+  /** Human-readable role name (e.g. "Abteilungsleitung") */
+  roleName?: string;
+  /** Profile picture URL from Hitobito */
+  picture?: string | null;
+}
+
+/** A node in the Organigramm tree, representing a group and its members */
+export interface OrganigrammNode {
+  group: {
+    id: number;
+    name: string;
+    shortName?: string | null;
+    type: string;
+  };
+  members: OrganigrammMember[];
+  children: OrganigrammNode[];
+}
+
+/** Cached Organigramm data stored in MongoDB */
+export interface OrganigrammCache {
+  rootGroupId: number;
+  fetchedAt: Date;
+  data: OrganigrammNode;
+}
+
+/** Response from the /api/organigramm endpoint */
+export interface OrganigrammResponse {
+  data: OrganigrammNode;
+  stale: boolean;
+  fetchedAt: string;
+}

--- a/scripts/seed-organigramm.ts
+++ b/scripts/seed-organigramm.ts
@@ -1,0 +1,271 @@
+/**
+ * Seed script: inserts a mock Organigramm tree into the hitobito-cache
+ * MongoDB collection so the component can be tested without real Hitobito access.
+ *
+ * Based on the real Pfadi Meilen Herrliberg org chart structure:
+ *   L1: Abteilungsleitung (Arwen, Canyella, Maui)
+ *   L2: Wolfsstufe (Rikki-Tikki-Tavi), Pfadistufe, Piostufe
+ *   L3: Meuten / Trupps / Equipes
+ *   L4: Gruppenleitung (Fähnli / Patrouille level)
+ *
+ * Usage:
+ *   bun run scripts/seed-organigramm.ts
+ *
+ * Requires MongoDB to be running (docker compose up -d).
+ */
+
+import { MongoClient } from "mongodb";
+
+const CONNECTION_STRING =
+  process.env.MONGODB_CONNECTION_STRING ??
+  "mongodb://root:example@localhost:27017";
+const DB_NAME = process.env.MONGODB_DB_NAME ?? "pfadimh-db";
+const COLLECTION = "hitobito-cache";
+const ROOT_GROUP_ID = 1234;
+
+const pic = (seed: string) =>
+  `https://api.dicebear.com/9.x/avataaars/svg?seed=${encodeURIComponent(seed)}`;
+
+function m(
+  id: number,
+  firstName: string,
+  lastName: string,
+  nickname: string | null,
+  role: string,
+  roleName: string,
+  hasPic: boolean
+) {
+  return {
+    id,
+    firstName,
+    lastName,
+    nickname,
+    role,
+    roleName,
+    picture: hasPic ? pic(`${firstName.toLowerCase()}-${id}`) : null,
+  };
+}
+
+const mockTree = {
+  rootGroupId: ROOT_GROUP_ID,
+  fetchedAt: new Date(),
+  data: {
+    // ═══════════════════════════════════════════════════════════
+    // L1 — Abteilungsleitung
+    // ═══════════════════════════════════════════════════════════
+    group: {
+      id: ROOT_GROUP_ID,
+      name: "Pfadi Meilen Herrliberg",
+      shortName: "Pfadi MH",
+      type: "Group::Abteilung",
+    },
+    members: [
+      m(1, "Lena", "Baumann", "Arwen", "Group::Abteilung::Abteilungsleitung", "Abteilungsleitung", true),
+      m(2, "Silvio", "Meier", "Canyella", "Group::Abteilung::Abteilungsleitung", "Abteilungsleitung", true),
+      m(3, "Florian", "Loew", "Maui", "Group::Abteilung::Abteilungsleitung", "Abteilungsleitung", true),
+      m(99, "System", "Admin", null, "Group::Abteilung::PowerUser", "PowerUser", false),
+    ],
+    children: [
+      // ═══════════════════════════════════════════════════════════
+      // L2 — Wolfsstufe (Rikki-Tikki-Tavi)
+      // ═══════════════════════════════════════════════════════════
+      {
+        group: { id: 2001, name: "Wolfsstufe", shortName: "Rikki-Tikki-Tavi", type: "Group::Woelfe" },
+        members: [
+          m(10, "Nina", "Roth", "Achaya", "Group::Woelfe::Stufenleitung", "Stufenleitung", true),
+          m(11, "Sophie", "Mueller", "Peppina", "Group::Woelfe::Stufenleitung", "Stufenleitung", true),
+          m(20, "Elena", "Gerber", "Zafia", "Group::Woelfe::Stufenleitung", "Stufenleitung", true),
+          m(21, "Laura", "Brunner", "Zelia", "Group::Woelfe::Stufenleitung", "Stufenleitung", false),
+        ],
+        children: [
+          // ─── L3 — Bienli (Meute Raschka) ───
+          {
+            group: { id: 3001, name: "Bienli", shortName: "Meute Raschka", type: "Group::Woelfe::Meute" },
+            members: [
+              m(10, "Nina", "Roth", "Achaya", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", true),
+              m(11, "Sophie", "Mueller", "Peppina", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", true),
+            ],
+            children: [
+              // ─── L4 — Bienli Gruppenleitung ───
+              {
+                group: { id: 4001, name: "Fähnli Raschka", shortName: null, type: "Group::Woelfe::Fahnli" },
+                members: [
+                  m(12, "Anna", "Keller", "Moana", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                  m(13, "Lara", "Fischer", "Ayeli", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", false),
+                  m(14, "Marco", "Huber", "Elua", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                ],
+                children: [],
+              },
+            ],
+          },
+          // ─── L3 — Wölfli (Meute Akela) ───
+          {
+            group: { id: 3002, name: "Wölfli", shortName: "Meute Akela", type: "Group::Woelfe::Meute" },
+            members: [
+              m(20, "Elena", "Gerber", "Zafia", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", true),
+              m(21, "Laura", "Brunner", "Zelia", "Group::Woelfe::Meute::Stufenleitung", "Stufenleitung", false),
+            ],
+            children: [
+              // ─── L4 — Wölfli Gruppenleitung ───
+              {
+                group: { id: 4002, name: "Fähnli Akela", shortName: null, type: "Group::Woelfe::Fahnli" },
+                members: [
+                  m(22, "Tim", "Schmid", "Artus", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", false),
+                  m(23, "Jonas", "Steiner", "Salero", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                  m(24, "Lena", "Widmer", "Pachica", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", true),
+                  m(25, "Nora", "Frei", "Malea", "Group::Woelfe::Fahnli::Leitung", "Gruppenleitung", false),
+                ],
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+
+      // ═══════════════════════════════════════════════════════════
+      // L2 — Pfadistufe
+      // ═══════════════════════════════════════════════════════════
+      {
+        group: { id: 2002, name: "Pfadistufe", shortName: "Pfadi", type: "Group::Pfadi" },
+        members: [
+          m(30, "David", "Graf", "Baski", "Group::Pfadi::Stufenleitung", "Stufenleitung", true),
+          m(31, "Sarah", "Bieri", "Salita", "Group::Pfadi::Stufenleitung", "Stufenleitung", true),
+          m(40, "Robin", "Hartmann", "Maeva", "Group::Pfadi::Stufenleitung", "Stufenleitung", true),
+          m(41, "Julia", "Lang", "Nepomuk", "Group::Pfadi::Stufenleitung", "Stufenleitung", false),
+        ],
+        children: [
+          // ─── L3 — Atlantik-Karibik ───
+          {
+            group: { id: 3003, name: "Atlantik-Karibik", shortName: null, type: "Group::Pfadi::Trupp" },
+            members: [
+              m(30, "David", "Graf", "Baski", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", true),
+              m(31, "Sarah", "Bieri", "Salita", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", true),
+            ],
+            children: [
+              // ─── L4 — Ashera (sub-group of Atlantik-Karibik) ───
+              {
+                group: { id: 4003, name: "Ashera", shortName: null, type: "Group::Pfadi::Patrouille" },
+                members: [
+                  m(32, "Fabian", "Kunz", "Chippa", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  m(33, "Mia", "Gerber", "Maymana", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  m(34, "Noah", "Ammann", "Arisca", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  m(35, "Lea", "Moser", "Calima", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  m(36, "Jan", "Ritter", "Malinka", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                ],
+                children: [],
+              },
+            ],
+          },
+          // ─── L3 — OFI ───
+          {
+            group: { id: 3004, name: "OFI", shortName: null, type: "Group::Pfadi::Trupp" },
+            members: [
+              m(40, "Robin", "Hartmann", "Maeva", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", true),
+              m(41, "Julia", "Lang", "Nepomuk", "Group::Pfadi::Trupp::Stufenleitung", "Stufenleitung", false),
+            ],
+            children: [
+              // ─── L4 — OFI Gruppenleitung ───
+              {
+                group: { id: 4004, name: "Patrouille OFI", shortName: null, type: "Group::Pfadi::Patrouille" },
+                members: [
+                  m(42, "Nico", "Pfister", "Rajah", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  m(43, "Amelie", "Berger", "Bachuja", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  m(44, "Andrin", "Bucher", "Leonidas", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  m(45, "Clara", "Suter", "Thor", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                  m(46, "Dario", "Meier", "Pyro", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", false),
+                  m(47, "Eva", "Schmid", "Battino", "Group::Pfadi::Patrouille::Leitung", "Gruppenleitung", true),
+                ],
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+
+      // ═══════════════════════════════════════════════════════════
+      // L2 — Piostufe
+      // ═══════════════════════════════════════════════════════════
+      {
+        group: { id: 2003, name: "Piostufe", shortName: "Pio", type: "Group::Pio" },
+        members: [
+          m(50, "Patrick", "Wyss", "Maui", "Group::Pio::Stufenleitung", "Stufenleitung", true),
+        ],
+        children: [
+          // ─── L3 — Makena ───
+          {
+            group: { id: 3005, name: "Makena", shortName: null, type: "Group::Pio::Equipe" },
+            members: [
+              m(50, "Patrick", "Wyss", "Maui", "Group::Pio::Equipe::Stufenleitung", "Stufenleitung", true),
+            ],
+            children: [
+              // ─── L4 — Makena Gruppenleitung ───
+              {
+                group: { id: 4005, name: "Equipe Makena", shortName: null, type: "Group::Pio::Equipe::Gruppe" },
+                members: [
+                  m(51, "Carla", "Stocker", "Salita", "Group::Pio::Equipe::Leitung", "Gruppenleitung", true),
+                  m(52, "Lars", "Engel", "Twist", "Group::Pio::Equipe::Leitung", "Gruppenleitung", false),
+                ],
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyNode = { members: any[]; children: AnyNode[] };
+
+function countNodes(node: AnyNode): number {
+  return 1 + node.children.reduce((sum, c) => sum + countNodes(c), 0);
+}
+
+function countMembers(node: AnyNode): number {
+  return (
+    node.members.length +
+    node.children.reduce((sum, c) => sum + countMembers(c), 0)
+  );
+}
+
+function maxDepth(node: AnyNode, depth = 1): number {
+  if (node.children.length === 0) return depth;
+  return Math.max(...node.children.map((c) => maxDepth(c, depth + 1)));
+}
+
+// ─── Seed ───────────────────────────────────────────────────────
+
+async function seed() {
+  const client = new MongoClient(CONNECTION_STRING);
+  try {
+    await client.connect();
+    const db = client.db(DB_NAME);
+    const collection = db.collection(COLLECTION);
+
+    await collection.updateOne(
+      { rootGroupId: ROOT_GROUP_ID },
+      { $set: mockTree },
+      { upsert: true }
+    );
+
+    const groups = countNodes(mockTree.data);
+    const members = countMembers(mockTree.data);
+    const depth = maxDepth(mockTree.data);
+
+    console.log(
+      `Seeded Organigramm cache for group ${ROOT_GROUP_ID} ("${mockTree.data.group.name}")`
+    );
+    console.log(`  - ${groups} groups across ${depth} layers`);
+    console.log(`  - ${members} total members`);
+    console.log(`  - ${mockTree.data.children.length} direct child groups`);
+    console.log(`\nUse group ID ${ROOT_GROUP_ID} in the Organigramm component.`);
+    console.log(`To test role exclusion, add "PowerUser" to the excluded roles field.`);
+  } finally {
+    await client.close();
+  }
+}
+
+seed().catch(console.error);


### PR DESCRIPTION
## Summary

- Adds a procedurally generated organizational chart (Organigramm) Puck editor component that pulls group/role/person data from Hitobito (MiData), caches it in MongoDB with 1-week TTL, and renders as an interactive tree
- Implements a CSS Grid-based tree layout with pixel-perfect sibling alignment, connector lines, and a `FitToWidth` scale-to-fit container that ensures the tree always fits the viewport (no horizontal scrolling on any screen size)
- Includes vendored `@pfadimh/hitobito-api` TypeScript client, Storybook stories with realistic seed data, configurable role exclusion, and responsive sizing at 3 breakpoints

## Details

### Data Pipeline
- **Vendored API client** (`lib/hitobito/api/`) — TypeScript wrapper for Hitobito REST API with Zod schemas
- **Recursive tree builder** (`lib/hitobito/fetch-organigramm.ts`) — BFS group traversal with concurrency-limited parallelism
- **MongoDB cache** (`hitobito-cache` collection) — 1-week TTL, stale fallback if Hitobito is unreachable
- **API route** (`GET /api/organigramm?groupId=X`) — cache-or-fetch with stale-while-revalidate

### UI Components
- **CompactCard** — Hierarchy-first cards showing group name, subtitle, comma-separated scout nicknames. Radix HoverCard popover for member details (avatars, full names, roles)
- **ChildrenGrid** — CSS Grid with 2 explicit rows for sibling card alignment. Row 1 auto-sizes to tallest cell so all cards' bottoms align regardless of content height
- **FitToWidth** — `ResizeObserver`-based container that applies `transform: scale()` to fit the tree within available width. No horizontal scrolling ever
- **Responsive sizing** — Cards, fonts, and connectors scale at 3 breakpoints (`<sm` / `sm` / `lg`)

### Editor Configuration
- Root group ID (Hitobito group to start from)
- Max depth (how deep to traverse)
- Excluded roles (comma-separated, e.g. `PowerUser`)
- Show/hide profile pictures in hover popovers

### Environment
- `HITOBITO_BASE_URL` + `HITOBITO_API_TOKEN` (optional, component shows "not configured" message if missing)
- Both must be set together (cross-validation in `lib/env.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Organigramm component to display interactive organizational charts with customizable configuration options
  * Supports filtering by role exclusion, depth limits, and member visibility thresholds
  * Picture display can be toggled on or off
  * Implements intelligent caching for optimal performance when displaying organizational structure
  * Integrates with Hitobito API to fetch live organizational data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->