### PR TITLE
Fix auth crash and map SSO hierarchy levels to security roles

### DIFF
--- a/lib/auth/auth-client.ts
+++ b/lib/auth/auth-client.ts
@@ -6,6 +6,32 @@ import { getMockAuthProvider } from "./mock-auth-config";
 
 const USE_MOCK_AUTH = env.MOCK_AUTH === "true";
 
+/**
+ * Maps SSO helper `hirarchy_level` values to security-config role names.
+ * SSO helper outputs: "admin" | "leader" | "member" | "none"
+ * Security config expects: "Admin" | "Leiter" | "JungLeiter"
+ */
+const HIERARCHY_TO_ROLES: Record<string, string[]> = {
+  admin: ["Admin"],
+  leader: ["Leiter"],
+  member: ["JungLeiter"],
+  none: [],
+};
+
+function resolveRoles(profile: Record<string, unknown> | undefined): string[] {
+  const directRoles = profile?.roles;
+  if (Array.isArray(directRoles) && directRoles.length > 0) {
+    return directRoles as string[];
+  }
+
+  const level = profile?.hirarchy_level;
+  if (typeof level === "string" && level in HIERARCHY_TO_ROLES) {
+    return HIERARCHY_TO_ROLES[level];
+  }
+
+  return [];
+}
+
 const { handlers, signIn, signOut, auth } = NextAuth({
   basePath: "/auth",
   providers: [
@@ -32,10 +58,14 @@ const { handlers, signIn, signOut, auth } = NextAuth({
       }
 
       if (user) {
-        token.roles = (user as any).roles || profile?.roles;
+        const userRoles = (user as any).roles;
+        token.roles =
+          Array.isArray(userRoles) && userRoles.length > 0
+            ? userRoles
+            : resolveRoles(profile as Record<string, unknown> | undefined);
       }
 
-      if (token.roles && !token.permissions) {
+      if (token.roles && (token.roles as string[]).length > 0 && !token.permissions) {
         token.permissions = await fetchPermissions(token.roles as string[]);
       }
 

--- a/lib/security/permission-evaluator.ts
+++ b/lib/security/permission-evaluator.ts
@@ -14,9 +14,9 @@ export function hasPermission(
   policy: Policy
 ): boolean {
   if (!session?.user) return false;
-  if (session.user.permissions.includes("global-admin")) return true;
 
-  const sessionPermissions = session.user.permissions;
+  const sessionPermissions = session.user.permissions ?? [];
+  if (sessionPermissions.includes("global-admin")) return true;
 
   const anyPerms = policy.any ?? [];
   if (

--- a/testing/lib/permission-evaluator.test.node.ts
+++ b/testing/lib/permission-evaluator.test.node.ts
@@ -157,6 +157,16 @@ describe("hasPermission", () => {
   });
 
   describe("edge cases", () => {
+    test("returns false when session.user exists but permissions is undefined", () => {
+      const session = { user: {} } as unknown as Session;
+      expect(hasPermission(session, { any: ["page:update"] })).toBe(false);
+    });
+
+    test("returns true with empty policy when permissions is undefined", () => {
+      const session = { user: {} } as unknown as Session;
+      expect(hasPermission(session, {})).toBe(true);
+    });
+
     test("handles user with empty permissions array", () => {
       const session = createSession([]);
       expect(hasPermission(session, { any: ["page:update"] })).toBe(false);


### PR DESCRIPTION
## Summary

- **Fixes production crash** (`TypeError: Cannot read properties of undefined (reading 'includes')`) in `hasPermission` by guarding against undefined `permissions` with `?? []`
- **Maps SSO `hirarchy_level` to security-config role names** via `resolveRoles()` in the NextAuth JWT callback (`admin` → `Admin`, `leader` → `Leiter`, `member` → `JungLeiter`)
- Adds 2 test cases for undefined permissions edge case

## Context

The crash occurs when a user authenticates via Keycloak but `hirarchy_level` was never reaching the token (no IDP/client mappers existed). This left `session.user.permissions` as `undefined`, crashing `permission-evaluator.ts:17`.

### Server-side fixes already applied:
1. **Keycloak IDP mapper** added — stores `hirarchy_level` from SSO helper as a user attribute
2. **Keycloak client protocol mapper** added — emits `hirarchy_level` in the token
3. **SSO helper `hierarchy_config.json`** updated — now has all 6 groups (was only 1)

### This PR (code changes):
1. `permission-evaluator.ts` — `permissions ?? []` prevents the crash
2. `auth-client.ts` — `resolveRoles()` translates `hirarchy_level` claim to role names the security config understands
3. Test coverage for undefined permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced permission evaluation to safely handle cases with missing or undefined permissions
  * Improved role resolution with automatic fallback mechanism for incomplete role assignments

* **Tests**
  * Added edge case test coverage for permission evaluation scenarios with undefined permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->